### PR TITLE
fix config test following the renamed config file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     fn test_from_path() {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("config.toml");
+        path.push("config.example.toml");
 
         let config = GesturesConfig::from_path(&path).unwrap();
         println!("{:?}", config)


### PR DESCRIPTION
Address issue #1 by patching the file name used in config test.