### PR TITLE
WIP: Add multitouch pinch gestures with centroid/spread tracking, robust error handling, Nix packaging, and other improvements

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
+fi
+
+use flake .#default

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/.direnv
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
+ "thiserror",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -569,6 +570,26 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.9.10"
 rustix = { version = "0.38", features = ["event"] }
+thiserror = "2.0.18"

--- a/config.example.toml
+++ b/config.example.toml
@@ -3,7 +3,7 @@
  kind = "SwipeDown"
  action = "notify-send 'Three Finger Swipe Down'"
  min_duration = 50
- mix_distance = 100.0
+ min_distance = 100.0
 
 [[gestures]]
 num_fingers = 2
@@ -47,7 +47,21 @@ on_edge = { Bottom = 300 }
 
 [[gestures]]
 num_fingers = 4
-kind = "Press"
-action = "notify-send 'Long Press' 'Four finger long press detected'"
+kind = "Hold"
+action = "notify-send 'Hold' 'Four finger long press detected'"
 min_duration = 500
 max_distance = 20.0
+
+[[gestures]]
+num_fingers = 4
+kind = "PinchOut"
+action = "notify-send 'Four Finger PinchOut'"
+min_duration = 50
+min_distance = 100.0
+
+[[gestures]]
+num_fingers = 4
+kind = "PinchIn"
+action = "notify-send 'Four Finger PinchIn'"
+min_duration = 50
+min_distance = 100.0

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, writeText
+, pkg-config
+, libinput
+, systemd
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "roland";
+  version = "01-02-2026-unstable";
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libinput
+    systemd
+  ];
+
+  cargoHash = "sha256-3r80j3UXQIIxhTIKozWcqxQSSRzDH8K1ND6vFTivXD8=";
+
+  meta = {
+    homepage = "https://github.com/oknozor/roland";
+    description = "A simple touch gesture recognizer for Linux";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774388614,
+        "narHash": "sha256-tFwzTI0DdDzovdE9+Ras6CUss0yn8P9XV4Ja6RjA+nU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1073dad219cb244572b74da2b20c7fe39cb3fa9e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774753967,
+        "narHash": "sha256-HpT5fE8JQSbAxolUnw3VgGAo3urVjcrgtB2rtoxURVw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "405b9b4c2c6c5a2b1d390524ce8a240729f34a96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+{
+  description = "Roland: Gesture daemon for Linux";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, rust-overlay }:
+  let
+    inherit (nixpkgs) lib;
+
+    systems = lib.filter (lib.hasSuffix "-linux") lib.systems.flakeExposed;
+
+    overlays = [ rust-overlay.overlays.default ];
+
+    pkgsFor = system: import nixpkgs {
+      inherit system overlays;
+      config.allowUnfree = true;
+    };
+
+    forAllSystems = f: builtins.listToAttrs (map (system: {
+      name = system;
+      value = f system (pkgsFor system);
+    }) systems);
+
+    shell = { mkShell, pkgsBuildHost, pkgsHostHost }:
+      mkShell {
+        nativeBuildInputs = with pkgsBuildHost; [
+          rustfmt
+          clippy
+          rustc
+          rust-analyzer
+          cargo-machete
+          libnotify
+          pkg-config
+          gdb
+        ] ++ (
+          let
+            rustToolchain = pkgsBuildHost.rust-bin.stable.latest.default.override {
+              extensions = [
+                "rust-src"
+                "rust-analyzer-preview"
+              ];
+              targets = [
+                "x86_64-unknown-linux-gnu"
+                "aarch64-unknown-linux-gnu"
+              ];
+            };
+          in [ rustToolchain ]
+        );
+
+        buildInputs = with pkgsHostHost; [
+          libinput
+          systemd
+        ];
+      };
+
+  in {
+    devShells = forAllSystems (system: pkgs: {
+      default = pkgs.callPackage shell {};
+    });
+
+    packages = forAllSystems (system: pkgs: {
+      default = pkgs.callPackage ./default.nix {};
+    });
+  };
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,76 +1,88 @@
-use std::time::Duration;
+use std::{process::Child, time::Duration};
 
 use serde::Deserialize;
+
+const SIN_PI_8: f64 = 0.38268;
 
 #[derive(Deserialize, Debug)]
 pub struct GesturesConfig {
     pub gestures: Vec<GestureConfig>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub struct GestureConfig {
-    num_fingers: u32,
-    kind: GestureKind,
+    num_fingers: usize,
     action: String,
     min_duration: Option<u64>,
     max_duration: Option<u64>,
-    max_distance: Option<f64>,
     min_distance: Option<f64>,
+    max_distance: Option<f64>,
+    kind: GestureKind,
     on_edge: Option<EdgeRequirement>,
 }
 
 impl GestureConfig {
-    pub fn run(&self) {
+    pub fn run(&self) -> Result<Child, std::io::Error> {
         std::process::Command::new("sh")
             .arg("-c")
             .arg(&self.action)
             .spawn()
-            .expect("Failed to execute command");
     }
 
     pub fn should_trigger(
         &self,
-        num_finger: u32,
+        num_finger: usize,
+        spread_diff: Option<f64>,
+        centroid_diff: Option<(f64, f64)>,
         start_position: (f64, f64),
-        current_position: (f64, f64),
         screen_size: (f64, f64),
         duration: Duration,
     ) -> bool {
+        let gestures = self.conclude_gestures(
+            num_finger,
+            spread_diff,
+            centroid_diff,
+            start_position,
+            screen_size,
+            duration,
+        );
+
+        if gestures.contains(&self.kind) {
+            tracing::debug!(
+                "Gesture concluded {num_finger}/{gestures:?} <==> Trigger target {}/{:?}",
+                self.num_fingers,
+                self.kind
+            );
+            return true;
+        }
+        return false;
+    }
+
+    fn conclude_gestures(
+        &self,
+        num_finger: usize,
+        spread_diff: Option<f64>,
+        centroid_diff: Option<(f64, f64)>,
+        start_position: (f64, f64),
+        screen_size: (f64, f64),
+        duration: Duration,
+    ) -> Vec<GestureKind> {
+        let mut gestures = Vec::with_capacity(3);
+
         if num_finger != self.num_fingers {
-            tracing::debug!("Gesture finger count mismatch, ignoring");
-            return false;
+            return gestures;
         }
 
         if let Some(min_duration) = self.min_duration
             && duration < Duration::from_millis(min_duration)
         {
-            tracing::debug!("Gesture duration below min_duration, ignoring");
-            return false;
+            return gestures;
         }
 
         if let Some(max_duration) = self.max_duration
             && duration > Duration::from_millis(max_duration)
         {
-            tracing::debug!("Gesture duration exceeds max_duration, ignoring");
-            return false;
-        }
-
-        let dx = current_position.0 - start_position.0;
-        let dy = current_position.1 - start_position.1;
-        let distance = (dx * dx + dy * dy).sqrt();
-
-        if let Some(min_distance) = self.min_distance
-            && distance < min_distance
-        {
-            tracing::debug!("Gesture distance below min_distance, ignoring");
-            return false;
-        }
-
-        if let Some(max_distance) = self.max_distance
-            && distance > max_distance
-        {
-            tracing::debug!("Gesture distance exceeds max_distance, ignoring");
-            return false;
+            return gestures;
         }
 
         if !self.is_on_screen_edge(
@@ -79,42 +91,56 @@ impl GestureConfig {
             screen_size.0,
             screen_size.1,
         ) {
-            tracing::debug!("Gesture not on screen edge, ignoring");
-            return false;
+            return gestures;
         }
 
-        match self.kind {
-            GestureKind::SwipeUp => {
-                if is_vertical(dx, dy) && dy < 0.0 {
-                    tracing::debug!("Gesture swipe up detected");
-                    return true;
-                }
-            }
-            GestureKind::SwipeDown => {
-                if is_vertical(dx, dy) && dy > 0.0 {
-                    tracing::debug!("Gesture swipe down detected");
-                    return true;
-                }
-            }
-            GestureKind::SwipeLeft => {
-                if is_horizontal(dx, dy) && dx < 0.0 {
-                    tracing::debug!("Gesture swipe left detected");
-                    return true;
-                }
-            }
-            GestureKind::SwipeRight => {
-                if is_horizontal(dx, dy) && dx > 0.0 {
-                    tracing::debug!("Gesture swipe right detected");
-                    return true;
-                }
-            }
-            GestureKind::Press => {
-                // Press gesture does not depend on movement
-                return true;
-            }
+        let min_distance = self.min_distance.unwrap_or(0.0);
+
+        let (dx, dy) = match centroid_diff {
+            Some(diff) => diff,
+            None => return gestures,
+        };
+        let dr = dx.hypot(dy);
+
+        if dr < min_distance {
+            return gestures;
         }
 
-        false
+        if let Some(max_distance) = self.max_distance
+            && dr > max_distance
+        {
+            return gestures;
+        }
+
+        gestures.push(GestureKind::Hold);
+
+        match spread_diff {
+            Some(ds) if ds > min_distance => gestures.push(GestureKind::PinchOut),
+            Some(ds) if ds < -min_distance => gestures.push(GestureKind::PinchIn),
+            _ => {}
+        }
+
+        let projected = dx.hypot(dy) * SIN_PI_8;
+        match (
+            dx > projected,
+            dx < -projected,
+            dy > projected,
+            dy < -projected,
+        ) {
+            (true, false, false, false) => gestures.push(GestureKind::SwipeRight),
+            (false, true, false, false) => gestures.push(GestureKind::SwipeLeft),
+            (false, false, true, false) => gestures.push(GestureKind::SwipeDown),
+            (false, false, false, true) => gestures.push(GestureKind::SwipeUp),
+
+            (true, false, true, false) => gestures.push(GestureKind::SwipeDownRight),
+            (false, true, true, false) => gestures.push(GestureKind::SwipeDownLeft),
+            (true, false, false, true) => gestures.push(GestureKind::SwipeUpRight),
+            (false, true, false, true) => gestures.push(GestureKind::SwipeUpLeft),
+
+            _ => {}
+        };
+
+        return gestures;
     }
 
     fn is_on_screen_edge(&self, x: f64, y: f64, screen_width: f64, screen_height: f64) -> bool {
@@ -128,7 +154,7 @@ impl GestureConfig {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub enum EdgeRequirement {
     Top(u32),
     Left(u32),
@@ -136,13 +162,19 @@ pub enum EdgeRequirement {
     Right(u32),
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq, Eq)]
 pub enum GestureKind {
     SwipeUp,
     SwipeDown,
     SwipeLeft,
     SwipeRight,
-    Press,
+    SwipeUpRight,
+    SwipeUpLeft,
+    SwipeDownRight,
+    SwipeDownLeft,
+    PinchIn,
+    PinchOut,
+    Hold,
 }
 
 impl GesturesConfig {
@@ -151,14 +183,6 @@ impl GesturesConfig {
         let config: GesturesConfig = toml::from_str(&content)?;
         Ok(config)
     }
-}
-
-fn is_vertical(dx: f64, dy: f64) -> bool {
-    dy.abs() > dx.abs()
-}
-
-fn is_horizontal(dx: f64, dy: f64) -> bool {
-    dx.abs() > dy.abs()
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     fn test_from_path() {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("config.toml");
+        path.push("config.example.toml");
 
         let config = GesturesConfig::from_path(&path).unwrap();
         println!("{:?}", config)

--- a/src/gesture.rs
+++ b/src/gesture.rs
@@ -1,12 +1,54 @@
-use std::time::Instant;
+use std::{
+    process::Child,
+    time::{Duration, Instant},
+};
+
+use thiserror::Error;
 
 use crate::config::GesturesConfig;
 
+const MAX_FINGERS: usize = 4;
+
+#[derive(Error, Debug)]
+pub enum GestureError {
+    #[error("no active touches/fingers")]
+    NoActiveTouch,
+    #[error("no matching gesture found")]
+    NoGestureMatched,
+    #[error("failed to execute gesture command: {0}")]
+    CommandFailed(#[from] std::io::Error),
+}
+
+#[derive(Debug)]
+pub struct TouchTrace {
+    slot: Option<u32>,
+    init_pos: (f64, f64),
+    current_pos: (f64, f64),
+    start_time: Instant,
+}
+
+impl TouchTrace {
+    pub fn new(slot: Option<u32>, x: f64, y: f64) -> Self {
+        Self {
+            slot,
+            init_pos: (x, y),
+            current_pos: (x, y),
+            start_time: Instant::now(),
+        }
+    }
+
+    pub fn current_distance_to(&self, x: f64, y: f64) -> f64 {
+        (x - self.current_pos.0).hypot(y - self.current_pos.1)
+    }
+
+    pub fn init_distance_to(&self, x: f64, y: f64) -> f64 {
+        (x - self.init_pos.0).hypot(y - self.init_pos.1)
+    }
+}
+
 #[derive(Debug)]
 pub struct GestureState {
-    position: (f64, f64),
-    active_touches: u32,
-    swipe: Option<Gesture>,
+    traces: Vec<TouchTrace>,
     config: GesturesConfig,
     screen_dimensions: (f64, f64),
 }
@@ -14,95 +56,128 @@ pub struct GestureState {
 impl GestureState {
     pub fn new(config: GesturesConfig, screen_width: f64, screen_height: f64) -> Self {
         Self {
-            position: (0.0, 0.0),
-            active_touches: 0,
-            swipe: None,
+            traces: Vec::with_capacity(MAX_FINGERS),
             config,
             screen_dimensions: (screen_width, screen_height),
         }
     }
-}
 
-#[derive(Debug)]
-struct Gesture {
-    start_position: (f64, f64),
-    start_time: Instant,
-    triggered: bool,
-}
-
-impl Gesture {
-    fn new(start_position: (f64, f64)) -> Self {
-        tracing::debug!("New gesture with position {start_position:?}");
-        Self {
-            start_position,
-            start_time: Instant::now(),
-            triggered: false,
+    pub fn update(&mut self, slot: Option<u32>, x: f64, y: f64) {
+        for t in self.traces.iter_mut().filter(|t| t.slot == slot) {
+            t.current_pos = (x, y);
         }
-    }
-}
 
-impl GestureState {
-    pub fn update(&mut self, x: f64, y: f64) {
-        tracing::trace!("Updating position to ({}, {})", x, y);
-        self.position = (x, y);
-        self.check_press_gestures();
+        self.handle_gesture();
     }
 
-    fn check_press_gestures(&mut self) {
-        if let Some(gesture) = &mut self.swipe {
-            if gesture.triggered {
-                return;
-            }
-
-            let duration = gesture.start_time.elapsed();
-
-            for gesture_config in self.config.gestures.iter() {
-                if gesture_config.should_trigger(
-                    self.active_touches,
-                    gesture.start_position,
-                    self.position,
-                    self.screen_dimensions,
-                    duration,
-                ) {
-                    tracing::info!("Triggering press gesture: {:?}", gesture_config);
-                    gesture_config.run();
-                    gesture.triggered = true;
-                    break;
-                }
-            }
-        }
+    pub fn touch_down(&mut self, slot: Option<u32>, x: f64, y: f64) {
+        self.traces.push(TouchTrace::new(slot, x, y))
     }
 
-    pub fn handle_touch_down(&mut self, x: f64, y: f64) {
-        self.position = (x, y);
-        self.active_touches += 1;
-        tracing::trace!("Active touches incremented {}", self.active_touches);
-        tracing::debug!("Touch down at {:?}", self.position);
-        self.swipe = Some(Gesture::new(self.position));
+    pub fn touch_up(&mut self, slot: Option<u32>) {
+        self.handle_gesture();
+        self.traces.retain(|t| t.slot != slot);
     }
 
-    pub fn handle_touch_up(&mut self) {
-        if let Some(swipe) = self.swipe.take() {
-            if !swipe.triggered {
-                for gesture in self.config.gestures.iter() {
-                    let duration = swipe.start_time.elapsed();
-                    if gesture.should_trigger(
-                        self.active_touches,
-                        swipe.start_position,
-                        self.position,
-                        self.screen_dimensions,
-                        duration,
-                    ) {
-                        tracing::info!("Triggering gesture: {:?}", gesture);
-                        gesture.run();
-                        break;
+    fn init_centeroid(&self) -> Option<(f64, f64)> {
+        if self.traces.is_empty() {
+            return None;
+        };
+
+        let n = self.traces.len() as f64;
+        let sum_x: f64 = self.traces.iter().map(|t| t.init_pos.0).sum();
+        let sum_y: f64 = self.traces.iter().map(|t| t.init_pos.1).sum();
+
+        Some((sum_x / n, sum_y / n))
+    }
+
+    fn current_centroid(&self) -> Option<(f64, f64)> {
+        if self.traces.is_empty() {
+            return None;
+        };
+
+        let n = self.traces.len() as f64;
+        let sum_x: f64 = self.traces.iter().map(|t| t.current_pos.0).sum();
+        let sum_y: f64 = self.traces.iter().map(|t| t.current_pos.1).sum();
+
+        Some((sum_x / n, sum_y / n))
+    }
+
+    fn init_spread(&self) -> Option<f64> {
+        let n = self.traces.len() as f64;
+        self.init_centeroid().map(|(cx, cy)| {
+            self.traces
+                .iter()
+                .map(|t| t.init_distance_to(cx, cy))
+                .sum::<f64>()
+                / n
+        })
+    }
+
+    fn current_spread(&self) -> Option<f64> {
+        let n = self.traces.len() as f64;
+        self.current_centroid().map(|(cx, cy)| {
+            self.traces
+                .iter()
+                .map(|t| t.current_distance_to(cx, cy))
+                .sum::<f64>()
+                / n
+        })
+    }
+
+    fn dispatch(&self) -> Result<Child, GestureError> {
+        let spread_diff = self
+            .current_spread()
+            .zip(self.init_spread())
+            .map(|(n, o)| n - o);
+
+        let centroid_diff = self
+            .current_centroid()
+            .zip(self.init_centeroid())
+            .map(|((xn, yn), (xo, yo))| (xn - xo, yn - yo));
+
+        tracing::debug!("Spread: {spread_diff:?}, Centroid: {centroid_diff:?}");
+
+        for c in &self.config.gestures {
+            let init_centeroid = self.init_centeroid().ok_or(GestureError::NoActiveTouch)?;
+            let longest_duration = self.longest_duration().ok_or(GestureError::NoActiveTouch)?;
+
+            if c.should_trigger(
+                self.traces.len(),
+                spread_diff,
+                centroid_diff,
+                init_centeroid,
+                self.screen_dimensions,
+                longest_duration,
+            ) {
+                tracing::debug!("Gesture {c:?} concluded");
+                match c.run() {
+                    Ok(child) => return Ok(child),
+                    Err(e) => {
+                        tracing::error!("Failed to run command: {e}");
+                        return Err(GestureError::CommandFailed(e.into()));
                     }
                 }
             }
-
-            tracing::debug!("remove active touch");
-            self.active_touches = 0;
-            self.swipe = None;
         }
+        Err(GestureError::NoGestureMatched)
+    }
+
+    fn handle_gesture(&mut self) {
+        match self.dispatch() {
+            Ok(_) => self.traces.clear(),
+            Err(GestureError::CommandFailed(e)) => {
+                tracing::error!("Failed to run gesture command: {e}");
+                self.traces.clear();
+            }
+            _ => {}
+        }
+    }
+
+    fn longest_duration(&self) -> Option<Duration> {
+        self.traces
+            .iter()
+            .map(|trace| Instant::now().saturating_duration_since(trace.start_time))
+            .max()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use input::event::TouchEvent;
-use input::event::touch::TouchEventPosition;
+use input::event::touch::{TouchEventPosition, TouchEventSlot};
 use input::{Event as InputEvent, Libinput, LibinputInterface};
 use rustix::event::{PollFd, PollFlags, poll};
 use std::fs::{File, OpenOptions};
@@ -74,18 +74,20 @@ fn main() {
             match event {
                 InputEvent::Touch(TouchEvent::Motion(touch_event)) => {
                     state.update(
+                        touch_event.slot(),
                         touch_event.x_transformed(width),
                         touch_event.y_transformed(height),
                     );
                 }
                 InputEvent::Touch(TouchEvent::Down(touch_event)) => {
-                    state.handle_touch_down(
+                    state.touch_down(
+                        touch_event.slot(),
                         touch_event.x_transformed(width),
                         touch_event.y_transformed(height),
                     );
                 }
-                InputEvent::Touch(TouchEvent::Up(_)) => {
-                    state.handle_touch_up();
+                InputEvent::Touch(TouchEvent::Up(touch_event)) => {
+                    state.touch_up(touch_event.slot());
                 }
                 _ => {}
             }
@@ -93,10 +95,45 @@ fn main() {
     }
 }
 
+enum Compositor {
+    Niri,
+    Hyprland,
+    Sway,
+}
+
+fn detect_compositor() -> Option<Compositor> {
+    let desktop = std::env::var("XDG_CURRENT_DESKTOP")
+        .unwrap_or_default()
+        .to_lowercase();
+
+    match (
+        desktop.as_str(),
+        std::env::var("NIRI_SOCKET").is_ok(),
+        std::env::var("HYPRLAND_INSTANCE_SIGNATURE").is_ok(),
+        std::env::var("SWAYSOCK").is_ok(),
+    ) {
+        (_, true, _, _) => Some(Compositor::Niri),
+        (_, _, true, _) => Some(Compositor::Hyprland),
+        (_, _, _, true) => Some(Compositor::Sway),
+        (d, _, _, _) if d.contains("niri") => Some(Compositor::Niri),
+        (d, _, _, _) if d.contains("hyprland") => Some(Compositor::Hyprland),
+        (d, _, _, _) if d.contains("sway") => Some(Compositor::Sway),
+        _ => None,
+    }
+}
+
 fn get_output_dimensions() -> Option<(u32, u32)> {
+    match detect_compositor()? {
+        Compositor::Niri => get_output_dimensions_niri(),
+        Compositor::Hyprland => get_output_dimensions_hyprland(),
+        Compositor::Sway => get_output_dimensions_sway(),
+    }
+}
+
+fn get_output_dimensions_niri() -> Option<(u32, u32)> {
     #[derive(serde::Deserialize)]
     struct OutputData {
-        logical: LogicalDimensions,
+        logical: Option<LogicalDimensions>,
     }
 
     #[derive(serde::Deserialize)]
@@ -106,9 +143,7 @@ fn get_output_dimensions() -> Option<(u32, u32)> {
     }
 
     let output = Command::new("niri")
-        .arg("msg")
-        .arg("-j")
-        .arg("outputs")
+        .args(["msg", "-j", "outputs"])
         .output()
         .ok()?;
 
@@ -116,12 +151,68 @@ fn get_output_dimensions() -> Option<(u32, u32)> {
         return None;
     }
 
-    let json_str = String::from_utf8(output.stdout).ok()?;
     let outputs: std::collections::HashMap<String, OutputData> =
-        serde_json::from_str(&json_str).ok()?;
+        serde_json::from_slice(&output.stdout).ok()?;
 
     outputs
         .values()
-        .next()
-        .map(|output_data| (output_data.logical.width, output_data.logical.height))
+        .find_map(|o| o.logical.as_ref().map(|l| (l.width, l.height)))
+}
+
+fn get_output_dimensions_hyprland() -> Option<(u32, u32)> {
+    #[derive(serde::Deserialize)]
+    struct Monitor {
+        width: u32,
+        height: u32,
+        focused: bool,
+    }
+
+    let output = Command::new("hyprctl")
+        .args(["monitors", "-j"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let monitors: Vec<Monitor> = serde_json::from_slice(&output.stdout).ok()?;
+
+    // prefer focused monitor, fall back to first
+    monitors
+        .iter()
+        .find(|m| m.focused)
+        .or_else(|| monitors.first())
+        .map(|m| (m.width, m.height))
+}
+
+fn get_output_dimensions_sway() -> Option<(u32, u32)> {
+    #[derive(serde::Deserialize)]
+    struct Output {
+        rect: Rect,
+        focused: bool,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Rect {
+        width: u32,
+        height: u32,
+    }
+
+    let output = Command::new("swaymsg")
+        .args(["-t", "get_outputs", "--raw"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let outputs: Vec<Output> = serde_json::from_slice(&output.stdout).ok()?;
+
+    outputs
+        .iter()
+        .find(|o| o.focused)
+        .or_else(|| outputs.first())
+        .map(|o| (o.rect.width, o.rect.height))
 }


### PR DESCRIPTION
# Support multitouch pinch gestures, improve error handling, and add Nix packaging

This PR adds proper multitouch support with centroid and spread tracking, introduces pinch-in and pinch-out gestures, renames the Press gesture to Hold, makes command failures non-fatal, and adds Nix flake and packaging support.

## Major changes

- Multitouch and pinch gesture support
  - New TouchTrace structure to track individual touch points.
  - Compute centroid (average position) and spread (distance between touches).
  - New gesture kinds: PinchIn and PinchOut, configurable with min_duration and min_distance.
  - Added support for diagonal swipes (SwipeUpRight, SwipeDownLeft, etc.).
  - Updated config.example.toml with examples for the new gestures and renamed Press to Hold.

- Improved error handling
  - Command failures no longer panic the daemon.
  - Introduced GestureError (including CommandFailed variant).
  - Gesture dispatch now returns Result and logs errors cleanly.

- Nix support
  - Added flake.nix and flake.lock using rust-overlay.
  - Added default.nix for building the package.
  - Added .envrc for direnv integration and a devShell with common Rust tools.

## Minor changes

- Renamed Press -> Hold everywhere (enum variant, documentation, config examples).
- Changed num_fingers type from u32 to usize in several places.
- Dynamic screen size detection for Niri, Hyprland, and Sway using their respective CLI tools.

## Discussions

- License issue: The upstream repository currently has no license file or declaration.  
  For this fork and the proposed merge, I suggest adding an MIT license (or BSD-3-Clause). The default.nix already declares MIT. Feedback on preferred license is welcome.

- Todo (future improvement):  
  Replace compositor-specific screen size detection with proper Wayland protocol usage (e.g., wlr-output-management or xdg-output) to make resolution detection fully compositor-agnostic.

## Testing notes

Tested primarily on Hyprland/Niri with 4-finger pinch and hold gestures.  
Pinch detection reacts to changes in spread while keeping the centroid relatively stable.  
Command errors are now logged instead of crashing the daemon.

All review, feedback, and discussions are welcome — especially on the multitouch math, gesture thresholds, license choice, and the proposed Wayland protocol improvement.