### PR TITLE
Formalize Project (v0.2.0)

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,1 @@
-#!/usr/bin/env bash
-if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
-    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
-fi
-
-use flake .#default
+use flake

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+if ! has nix_direnv_version || ! nix_direnv_version 2.3.0; then
+    source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/2.3.0/direnvrc" "sha256-Dmd+j63L84wuzgyjITIfSxSD57Tx7v51DMxVZOsiUD8="
+fi
+
+use flake .#default

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+/.direnv
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.direnv
+
 /target
 /.direnv
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,9 +19,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -34,15 +34,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -84,20 +84,18 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
-name = "bitvec"
-version = "1.0.1"
+name = "cc"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
- "funty",
- "radium",
- "tap",
- "wyz",
+ "find-msvc-tools",
+ "shlex",
 ]
 
 [[package]]
@@ -107,16 +105,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -124,9 +116,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -136,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -148,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "color-eyre"
@@ -181,9 +173,15 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "equivalent"
@@ -202,18 +200,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "evdev"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b686663ba7f08d92880ff6ba22170f1df4e83629341cba34cf82cd65ebea99"
-dependencies = [
- "bitvec",
- "cfg-if",
- "libc",
- "nix",
-]
-
-[[package]]
 name = "eyre"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,10 +210,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "funty"
-version = "2.0.0"
+name = "find-msvc-tools"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "gimli"
@@ -237,9 +223,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -261,9 +247,9 @@ checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -271,9 +257,9 @@ dependencies = [
 
 [[package]]
 name = "input"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbdc09524a91f9cacd26f16734ff63d7dc650daffadd2b6f84d17a285bd875a9"
+checksum = "f9793345a65d71317763a33066b5d8351f8760dde8d4930fe9e39b5f14a7959d"
 dependencies = [
  "bitflags",
  "input-sys",
@@ -284,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "input-sys"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd4f5b4d1c00331c5245163aacfe5f20be75b564c7112d45893d4ae038119eb0"
+checksum = "36eee07d8e02bd95bf52b2e642cf13d33701b94c6e4b04fbf1d1fb07e9cb19e7"
 
 [[package]]
 name = "io-lifetimes"
@@ -306,12 +292,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "itoa"
-version = "1.0.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,9 +299,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libudev-sys"
@@ -335,21 +315,21 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "miniz_oxide"
@@ -358,18 +338,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
-]
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
 ]
 
 [[package]]
@@ -392,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -404,45 +372,48 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.3"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6901729fa79e91a0913333229e9ca5dc725089d1c363b2f4b4760709dc4a52"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.42"
+name = "quick-xml"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
- "proc-macro2",
+ "memchr",
 ]
 
 [[package]]
-name = "radium"
-version = "0.7.0"
+name = "quote"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "roland"
@@ -450,35 +421,35 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "color-eyre",
- "evdev",
  "input",
  "libc",
  "rustix",
  "serde",
- "serde_json",
  "thiserror",
  "toml",
  "tracing",
  "tracing-subscriber",
+ "wayland-client",
+ "wayland-protocols",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -512,23 +483,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.147"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af14725505314343e673e9ecb7cd7e8a36aa9791eb936235a3567cc31447ae4"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
-]
-
-[[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -541,6 +499,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "smallvec"
@@ -556,20 +520,14 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "thiserror"
@@ -602,9 +560,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0825052159284a1a8b4d6c0c86cbc801f2da5afd2b225fa548c72f2e74002f48"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -617,27 +575,27 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tracing"
@@ -694,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "nu-ansi-term",
  "sharded-slab",
@@ -720,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "utf8parse"
@@ -737,6 +695,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,16 +763,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -775,29 +781,13 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -807,22 +797,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -831,28 +809,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -861,22 +821,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -885,28 +833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
 name = "winnow"
-version = "0.7.14"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
-
-[[package]]
-name = "wyz"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
-dependencies = [
- "tap",
-]
-
-[[package]]
-name = "zmij"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0095ecd462946aa3927d9297b63ef82fb9a5316d7a37d134eeb36e58228615a"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_json",
+ "thiserror",
  "toml",
  "tracing",
  "tracing-subscriber",
@@ -569,6 +570,26 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "thread_local"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.9.10"
 rustix = { version = "0.38", features = ["event"] }
+thiserror = "2.0.18"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,15 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-evdev = "0.13.2"
 clap = { version = "4", features = ["derive"] }
 color-eyre = "0.6"
-input = "0.9.1"
+input = "0.10.0"
 libc = "0.2.178"
 tracing = "0.1"
 tracing-subscriber = "0.3.0"
-serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-toml = "0.9.10"
-rustix = { version = "0.38", features = ["event"] }
+toml = "1.1.2"
+rustix = { version = "1.1.4", features = ["event"] }
+wayland-client = "0.31"
+wayland-protocols = { version = "0.32", features = ["client", "unstable"] }
 thiserror = "2.0.18"

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ A compositor-agnostic touch gesture recognizer for Linux, built on top of the `i
 - Duration and distance thresholds
 - Configurable actions via shell commands
 
+## Permissions
+
+Roland requires access to `/dev/input` devices. Your user must be in the `input` group.
+
+On NixOS, add it to your user configuration:
+
+```nix
+users.users.yourname.extraGroups = [ "input" ];
+```
+
+Then log out and back in for the group membership to take effect.
+
 ## Usage
 
 ### Standalone
@@ -18,6 +30,7 @@ A compositor-agnostic touch gesture recognizer for Linux, built on top of the `i
 ```sh
    cargo build --release
 ```
+
 2. Run the binary:
 ```sh
    ./target/release/roland --config config.example.toml
@@ -30,28 +43,26 @@ See [config.example.toml](config.example.toml) for configuration reference.
 Roland ships both an overlay (to add `pkgs.roland`) and a Home Manager module.
 **Both must be applied.** The module references `pkgs.roland` from the overlay.
 
-#### 1. Add the input
+1. Add the input:
 
 ```nix
 inputs.roland.url = "github:hftsai256/roland";
 inputs.roland.inputs.nixpkgs.follows = "nixpkgs";
 ```
 
-#### 2. Apply the overlay
-
-The overlay bundles `rust-overlay` internally, so no additional overlays are needed.
+2. Apply the overlay:
 
 ```nix
 nixpkgs.overlays = [ inputs.roland.overlays.default ];
 ```
 
-#### 3. Import the Home Manager module
+3. Import the Home Manager module:
 
 ```nix
 imports = [ inputs.roland.homeModules.default ];
 ```
 
-#### 4. Configure
+4. Configure example:
 
 ```nix
 services.roland = {
@@ -74,8 +85,6 @@ services.roland = {
   ];
 };
 ```
-
-See [config.example.toml](config.example.toml) for all available gesture options.
 
 ## Configuration Reference
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,91 @@
 # Roland
 
-A simple touch gesture recognizer for Linux, built on top of the `input` crate. This project is a temporary solution to enable touch gestures for my touch device on Niri.
+A compositor-agnostic touch gesture recognizer for Linux, built on top of the `input` crate.
 
 ## Features
 
-- Multi finger touch support
-- Recognize basic touch gestures (e.g., swipes).
-- Configurable gesture callbacks.
+- Multi-finger touch support
+- Recognizes swipe (8 directions), pinch, and hold gestures
+- Edge-aware gestures (trigger only from screen edges)
+- Duration and distance thresholds
+- Configurable actions via shell commands
 
 ## Usage
 
+### Standalone
+
 1. Build the project:
-   ```sh
+```sh
    cargo build --release
-   ```
+```
 2. Run the binary:
-   ```sh
-   ./target/release/roland
-   ```
+```sh
+   ./target/release/roland --config config.example.toml
+```
 
-## Configuration
+See [config.example.toml](config.example.toml) for configuration reference.
 
-See [config.example.toml](config.example.toml) for a detailed example configuration.
+### Nix Flake
+
+Roland ships both an overlay (to add `pkgs.roland`) and a Home Manager module.
+**Both must be applied.** The module references `pkgs.roland` from the overlay.
+
+#### 1. Add the input
+
+```nix
+inputs.roland.url = "github:hftsai256/roland";
+inputs.roland.inputs.nixpkgs.follows = "nixpkgs";
+```
+
+#### 2. Apply the overlay
+
+The overlay bundles `rust-overlay` internally, so no additional overlays are needed.
+
+```nix
+nixpkgs.overlays = [ inputs.roland.overlays.default ];
+```
+
+#### 3. Import the Home Manager module
+
+```nix
+imports = [ inputs.roland.homeModules.default ];
+```
+
+#### 4. Configure
+
+```nix
+services.roland = {
+  enable = true;
+  settings.gestures = [
+    {
+      num_fingers = 3;
+      kind = "SwipeUp";
+      min_duration = 50;
+      min_distance = 100.0;
+      action = ''hyprctl dispatch "hl.dsp.focus({ workspace = '+1' })"'';
+    }
+    {
+      num_fingers = 3;
+      kind = "SwipeDown";
+      min_duration = 50;
+      min_distance = 100.0;
+      action = ''hyprctl dispatch "hl.dsp.focus({ workspace = '-1' })"'';
+    }
+  ];
+};
+```
+
+See [config.example.toml](config.example.toml) for all available gesture options.
+
+## Configuration Reference
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `num_fingers` | int | yes | Number of fingers for the gesture |
+| `kind` | string | yes | `SwipeUp`, `SwipeDown`, `SwipeLeft`, `SwipeRight`, `SwipeUpLeft`, `SwipeUpRight`, `SwipeDownLeft`, `SwipeDownRight`, `PinchIn`, `PinchOut`, `Hold` |
+| `action` | string | yes | Shell command to execute |
+| `min_distance` | float | no | Minimum movement in pixels |
+| `max_distance` | float | no | Maximum movement in pixels |
+| `min_duration` | int (ms) | no | Minimum hold duration before gesture fires |
+| `max_duration` | int (ms) | no | Maximum hold duration |
+| `on_edge` | table | no | Restrict to screen edge: `{ Top = 300 }`, `{ Bottom = 300 }`, `{ Left = 300 }`, `{ Right = 300 }` |

--- a/assets/99-roland-input.rules
+++ b/assets/99-roland-input.rules
@@ -1,0 +1,3 @@
+# Allow members of the 'input' group to read input devices without sudo.
+# Install to /etc/udev/rules.d/99-roland-input.rules
+KERNEL=="event*", SUBSYSTEM=="input", GROUP="input", MODE="0660"

--- a/assets/setup-permissions.sh
+++ b/assets/setup-permissions.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Sets up the permissions needed to run roland without sudo.
+# Run once as root (or via sudo), then log out and back in.
+set -euo pipefail
+
+UDEV_RULE_SRC="$(cd "$(dirname "$0")" && pwd)/99-roland-input.rules"
+UDEV_RULE_DST="/etc/udev/rules.d/99-roland-input.rules"
+
+echo "==> Installing udev rule to ${UDEV_RULE_DST}"
+install -m 644 "${UDEV_RULE_SRC}" "${UDEV_RULE_DST}"
+
+echo "==> Reloading udev rules"
+udevadm control --reload-rules
+udevadm trigger --subsystem-match=input
+
+echo "==> Ensuring 'input' group exists"
+getent group input >/dev/null || groupadd --system input
+
+TARGET_USER="${SUDO_USER:-$USER}"
+echo "==> Adding '${TARGET_USER}' to the 'input' group"
+usermod -aG input "${TARGET_USER}"
+
+echo ""
+echo "Done. Log out and back in (or run 'newgrp input') for group membership to take effect."

--- a/config.example.toml
+++ b/config.example.toml
@@ -3,7 +3,7 @@
  kind = "SwipeDown"
  action = "notify-send 'Three Finger Swipe Down'"
  min_duration = 50
- mix_distance = 100.0
+ min_distance = 100.0
 
 [[gestures]]
 num_fingers = 2
@@ -47,7 +47,21 @@ on_edge = { Bottom = 300 }
 
 [[gestures]]
 num_fingers = 4
-kind = "Press"
-action = "notify-send 'Long Press' 'Four finger long press detected'"
+kind = "Hold"
+action = "notify-send 'Hold' 'Four finger long press detected'"
 min_duration = 500
 max_distance = 20.0
+
+[[gestures]]
+num_fingers = 4
+kind = "PinchOut"
+action = "notify-send 'Four Finger PinchOut'"
+min_duration = 50
+min_distance = 100.0
+
+[[gestures]]
+num_fingers = 4
+kind = "PinchIn"
+action = "notify-send 'Four Finger PinchIn'"
+min_duration = 50
+min_distance = 100.0

--- a/config.example.toml
+++ b/config.example.toml
@@ -47,21 +47,12 @@ on_edge = { Bottom = 300 }
 
 [[gestures]]
 num_fingers = 4
-kind = "Hold"
-action = "notify-send 'Hold' 'Four finger long press detected'"
-min_duration = 500
-max_distance = 20.0
-
-[[gestures]]
-num_fingers = 4
 kind = "PinchOut"
 action = "notify-send 'Four Finger PinchOut'"
-min_duration = 50
-min_distance = 100.0
+min_distance = 20
 
 [[gestures]]
 num_fingers = 4
 kind = "PinchIn"
 action = "notify-send 'Four Finger PinchIn'"
-min_duration = 50
-min_distance = 100.0
+min_distance = 20

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,33 @@
+{ lib
+, fetchFromGitHub
+, rustPlatform
+, writeText
+, pkg-config
+, libinput
+, systemd
+}:
+
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "roland";
+  version = "01-02-2026-unstable";
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    pkg-config
+  ];
+
+  buildInputs = [
+    libinput
+    systemd
+  ];
+
+  cargoHash = "sha256-3r80j3UXQIIxhTIKozWcqxQSSRzDH8K1ND6vFTivXD8=";
+
+  meta = {
+    homepage = "https://github.com/oknozor/roland";
+    description = "A simple touch gesture recognizer for Linux";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
+})

--- a/flake.lock
+++ b/flake.lock
@@ -34,28 +34,7 @@
     "root": {
       "inputs": {
         "crane": "crane",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1780284119,
-        "narHash": "sha256-y2wR4Mk6D/N1ID4FZa2oUMStCUxyIoRzmgOOpLzoWmo=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "51390d0bfca0a68a8c337d215a4bbeddc2ca616e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1774388614,
+        "narHash": "sha256-tFwzTI0DdDzovdE9+Ras6CUss0yn8P9XV4Ja6RjA+nU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1073dad219cb244572b74da2b20c7fe39cb3fa9e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774753967,
+        "narHash": "sha256-HpT5fE8JQSbAxolUnw3VgGAo3urVjcrgtB2rtoxURVw=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "405b9b4c2c6c5a2b1d390524ce8a240729f34a96",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,39 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1780099841,
+        "narHash": "sha256-EVZd2RsbpreRUDSi9rBwPY+ZxoyMaiEBbZxxhljbaS4=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "0532eb17955225173906d671fb36306bdeb1e2dc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774388614,
-        "narHash": "sha256-tFwzTI0DdDzovdE9+Ras6CUss0yn8P9XV4Ja6RjA+nU=",
+        "lastModified": 1780203844,
+        "narHash": "sha256-K5sT4jTpGs15ADhviMKNBH38REpPf5Q6mM1+N6cArVE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "1073dad219cb244572b74da2b20c7fe39cb3fa9e",
+        "rev": "b51242d7d43689db2f3be91bd05d5b24fbb469c4",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-25.11",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
@@ -29,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774753967,
-        "narHash": "sha256-HpT5fE8JQSbAxolUnw3VgGAo3urVjcrgtB2rtoxURVw=",
+        "lastModified": 1780284119,
+        "narHash": "sha256-y2wR4Mk6D/N1ID4FZa2oUMStCUxyIoRzmgOOpLzoWmo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "405b9b4c2c6c5a2b1d390524ce8a240729f34a96",
+        "rev": "51390d0bfca0a68a8c337d215a4bbeddc2ca616e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -3,17 +3,12 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
     crane.url = "github:ipetkov/crane";
   };
 
-  outputs = { self, nixpkgs, rust-overlay, crane }:
+  outputs = { self, nixpkgs, crane }:
   let
     overlays = [
-      rust-overlay.overlays.default
       self.overlays.default
     ];
 
@@ -30,27 +25,13 @@
       crossSystem.config = "aarch64-unknown-linux-gnu";
     };
 
-    mkRustToolchain = pkgs: pkgs.rust-bin.stable.latest.default.override {
-      extensions = [
-        "rust-src"
-        "rust-analyzer-preview"
-        "llvm-tools"
-      ];
-      targets = [
-        "x86_64-unknown-linux-gnu"
-        "aarch64-unknown-linux-gnu"
-      ];
-    };
-
     shell = { mkShell, pkgsBuildHost, pkgsHostHost }:
-      let
-        rustToolchain = mkRustToolchain pkgsBuildHost;
-      in mkShell {
+      mkShell {
         nativeBuildInputs = with pkgsBuildHost; [
-          rustToolchain
           rustfmt
           clippy
           rustc
+          cargo
           rust-analyzer
           cargo-machete
           cargo-llvm-cov
@@ -64,14 +45,13 @@
         ];
 
         shellHook = ''
-          export LLVM_COV="${rustToolchain}/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov"
-          export LLVM_PROFDATA="${rustToolchain}/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata"
+          export LLVM_COV="${pkgsBuildHost.llvmPackages.bintools}/bin/llvm-cov"
+          export LLVM_PROFDATA="${pkgsBuildHost.llvmPackages.bintools}/bin/llvm-profdata"
         '';
       };
 
   in {
     overlays.default = nixpkgs.lib.composeManyExtensions [
-      rust-overlay.overlays.default
       (import ./nix/overlay.nix { inherit crane; })
     ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,71 +1,87 @@
 {
-  description = "Roland: Gesture daemon for Linux";
+  description = "Roland -- Standalone touchscreen daemon";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    crane.url = "github:ipetkov/crane";
   };
 
-  outputs = { self, nixpkgs, rust-overlay }:
+  outputs = { self, nixpkgs, rust-overlay, crane }:
   let
-    inherit (nixpkgs) lib;
+    overlays = [
+      rust-overlay.overlays.default
+      self.overlays.default
+    ];
 
-    systems = lib.filter (lib.hasSuffix "-linux") lib.systems.flakeExposed;
-
-    overlays = [ rust-overlay.overlays.default ];
-
-    pkgsFor = system: import nixpkgs {
-      inherit system overlays;
+    pkgs = import nixpkgs {
+      inherit overlays;
       config.allowUnfree = true;
+      system = "x86_64-linux";
     };
 
-    forAllSystems = f: builtins.listToAttrs (map (system: {
-      name = system;
-      value = f system (pkgsFor system);
-    }) systems);
+    pkgsCross = import nixpkgs {
+      inherit overlays;
+      config.allowUnfree = true;
+      system = "x86_64-linux";
+      crossSystem.config = "aarch64-unknown-linux-gnu";
+    };
+
+    mkRustToolchain = pkgs: pkgs.rust-bin.stable.latest.default.override {
+      extensions = [
+        "rust-src"
+        "rust-analyzer-preview"
+        "llvm-tools"
+      ];
+      targets = [
+        "x86_64-unknown-linux-gnu"
+        "aarch64-unknown-linux-gnu"
+      ];
+    };
 
     shell = { mkShell, pkgsBuildHost, pkgsHostHost }:
-      mkShell {
+      let
+        rustToolchain = mkRustToolchain pkgsBuildHost;
+      in mkShell {
         nativeBuildInputs = with pkgsBuildHost; [
+          rustToolchain
           rustfmt
           clippy
           rustc
           rust-analyzer
           cargo-machete
-          libnotify
+          cargo-llvm-cov
           pkg-config
-          gdb
-        ] ++ (
-          let
-            rustToolchain = pkgsBuildHost.rust-bin.stable.latest.default.override {
-              extensions = [
-                "rust-src"
-                "rust-analyzer-preview"
-              ];
-              targets = [
-                "x86_64-unknown-linux-gnu"
-                "aarch64-unknown-linux-gnu"
-              ];
-            };
-          in [ rustToolchain ]
-        );
+          libnotify
+        ];
 
         buildInputs = with pkgsHostHost; [
           libinput
-          systemd
+          udev
         ];
+
+        shellHook = ''
+          export LLVM_COV="${rustToolchain}/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-cov"
+          export LLVM_PROFDATA="${rustToolchain}/lib/rustlib/x86_64-unknown-linux-gnu/bin/llvm-profdata"
+        '';
       };
 
   in {
-    devShells = forAllSystems (system: pkgs: {
-      default = pkgs.callPackage shell {};
-    });
+    overlays.default = import ./nix/overlay.nix { inherit crane; };
 
-    packages = forAllSystems (system: pkgs: {
-      default = pkgs.callPackage ./default.nix {};
-    });
+    packages.x86_64-linux = {
+      roland = pkgs.roland;
+      default = pkgs.roland;
+    };
+
+    homeManagerModules.default = import ./nix/modules/roland.nix;
+
+    devShells.x86_64-linux = {
+      default = pkgs.callPackage shell {};
+      cross = pkgsCross.callPackage shell {};
+    };
   };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -70,14 +70,17 @@
       };
 
   in {
-    overlays.default = import ./nix/overlay.nix { inherit crane; };
+    overlays.default = nixpkgs.lib.composeManyExtensions [
+      rust-overlay.overlays.default
+      (import ./nix/overlay.nix { inherit crane; })
+    ];
 
     packages.x86_64-linux = {
       roland = pkgs.roland;
       default = pkgs.roland;
     };
 
-    homeManagerModules.default = import ./nix/modules/roland.nix;
+    homeModules.default = ./nix/modules/roland.nix;
 
     devShells.x86_64-linux = {
       default = pkgs.callPackage shell {};

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+{
+  description = "Roland: Gesture daemon for Linux";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-25.11";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, rust-overlay }:
+  let
+    inherit (nixpkgs) lib;
+
+    systems = lib.filter (lib.hasSuffix "-linux") lib.systems.flakeExposed;
+
+    overlays = [ rust-overlay.overlays.default ];
+
+    pkgsFor = system: import nixpkgs {
+      inherit system overlays;
+      config.allowUnfree = true;
+    };
+
+    forAllSystems = f: builtins.listToAttrs (map (system: {
+      name = system;
+      value = f system (pkgsFor system);
+    }) systems);
+
+    shell = { mkShell, pkgsBuildHost, pkgsHostHost }:
+      mkShell {
+        nativeBuildInputs = with pkgsBuildHost; [
+          rustfmt
+          clippy
+          rustc
+          rust-analyzer
+          cargo-machete
+          libnotify
+          pkg-config
+          gdb
+        ] ++ (
+          let
+            rustToolchain = pkgsBuildHost.rust-bin.stable.latest.default.override {
+              extensions = [
+                "rust-src"
+                "rust-analyzer-preview"
+              ];
+              targets = [
+                "x86_64-unknown-linux-gnu"
+                "aarch64-unknown-linux-gnu"
+              ];
+            };
+          in [ rustToolchain ]
+        );
+
+        buildInputs = with pkgsHostHost; [
+          libinput
+          systemd
+        ];
+      };
+
+  in {
+    devShells = forAllSystems (system: pkgs: {
+      default = pkgs.callPackage shell {};
+    });
+
+    packages = forAllSystems (system: pkgs: {
+      default = pkgs.callPackage ./default.nix {};
+    });
+  };
+}

--- a/nix/modules/roland.nix
+++ b/nix/modules/roland.nix
@@ -1,9 +1,9 @@
-# Home-manager module for roland
 { config, lib, pkgs, ... }:
 
 let
   cfg = config.services.roland;
   toml = pkgs.formats.toml { };
+
 in {
   options.services.roland = {
     enable = lib.mkEnableOption "roland touch gesture daemon";
@@ -17,13 +17,13 @@ in {
 
     systemdTarget = lib.mkOption {
       type = lib.types.str;
-      default = cfg.systemdTarget;
+      default = "graphical-session.target";
       description = "Systemd target to bind the roland service to.";
     };
 
     # Accept either a path to an existing file or an inline attrset that gets
     # serialised to TOML.  Using an attrset lets you keep your gestures in Nix.
-    config = lib.mkOption {
+    settings = lib.mkOption {
       type = lib.types.either lib.types.path (lib.types.submodule {
         options.gestures = lib.mkOption {
           type = lib.types.listOf lib.types.attrs;
@@ -57,13 +57,13 @@ in {
     };
   };
 
-  config = lib.mkIf cfg.enable {
-    systemd.user.services.roland =
-      let
+  config = {
+    systemd.user.services.roland = lib.mkIf cfg.enable
+      (let
         configFile =
-          if lib.isPath cfg.config || lib.isString cfg.config
-          then cfg.config
-          else toml.generate "roland-config.toml" cfg.config;
+          if lib.isPath cfg.settings || lib.isString cfg.settings
+          then cfg.settings
+          else toml.generate "roland-config.toml" cfg.settings;
       in {
         Unit = {
           Description = "Roland touch gesture daemon";
@@ -79,6 +79,6 @@ in {
         };
 
         Install.WantedBy = [ cfg.systemdTarget ];
-      };
+      });
   };
 }

--- a/nix/modules/roland.nix
+++ b/nix/modules/roland.nix
@@ -1,0 +1,84 @@
+# Home-manager module for roland
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.services.roland;
+  toml = pkgs.formats.toml { };
+in {
+  options.services.roland = {
+    enable = lib.mkEnableOption "roland touch gesture daemon";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.roland;
+      defaultText = lib.literalExpression "pkgs.roland";
+      description = "The roland package to use.";
+    };
+
+    systemdTarget = lib.mkOption {
+      type = lib.types.str;
+      default = cfg.systemdTarget;
+      description = "Systemd target to bind the roland service to.";
+    };
+
+    # Accept either a path to an existing file or an inline attrset that gets
+    # serialised to TOML.  Using an attrset lets you keep your gestures in Nix.
+    config = lib.mkOption {
+      type = lib.types.either lib.types.path (lib.types.submodule {
+        options.gestures = lib.mkOption {
+          type = lib.types.listOf lib.types.attrs;
+          default = [];
+          description = "List of gesture definitions (passed through to TOML as-is).";
+        };
+      });
+      description = ''
+        Roland configuration.  Either a path to a TOML file or an attrset
+        that will be serialised to TOML automatically.
+      '';
+      example = lib.literalExpression ''
+        {
+          gestures = [
+            {
+              num_fingers = 1;
+              kind = "SwipeRight";
+              on_edge = { Left = 30; };
+              min_distance = 50.0;
+              action = "niri msg action focus-workspace-previous";
+            }
+          ];
+        }
+      '';
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.enum [ "error" "warn" "info" "debug" "trace" ];
+      default = "info";
+      description = "Log verbosity passed via RUST_LOG.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    systemd.user.services.roland =
+      let
+        configFile =
+          if lib.isPath cfg.config || lib.isString cfg.config
+          then cfg.config
+          else toml.generate "roland-config.toml" cfg.config;
+      in {
+        Unit = {
+          Description = "Roland touch gesture daemon";
+          After = [ cfg.systemdTarget ];
+          PartOf = [ cfg.systemdTarget ];
+        };
+
+        Service = {
+          ExecStart = "${lib.getExe cfg.package} --config ${configFile}";
+          Environment = [ "RUST_LOG=${cfg.logLevel}" ];
+          Restart = "on-failure";
+          RestartSec = "2s";
+        };
+
+        Install.WantedBy = [ cfg.systemdTarget ];
+      };
+  };
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,7 @@
+{ crane }:
+
+final: prev: {
+  roland = final.callPackage ./packages/roland.nix {
+    inherit crane;
+  };
+}

--- a/nix/packages/roland.nix
+++ b/nix/packages/roland.nix
@@ -4,8 +4,7 @@
 }:
 
 let
-  rustToolchain = pkgs.rust-bin.stable.latest.default;
-  craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+  craneLib = crane.mkLib pkgs;
 
   src = craneLib.cleanCargoSource (craneLib.path ../..);
 

--- a/nix/packages/roland.nix
+++ b/nix/packages/roland.nix
@@ -1,0 +1,31 @@
+{ lib
+, pkgs
+, crane
+}:
+
+let
+  rustToolchain = pkgs.rust-bin.stable.latest.default;
+  craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
+
+  src = craneLib.cleanCargoSource (craneLib.path ../..);
+
+  commonArgs = {
+    inherit src;
+
+    nativeBuildInputs = [ pkgs.pkg-config ];
+    buildInputs = [ pkgs.libinput pkgs.udev ];
+  };
+
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+in craneLib.buildPackage (commonArgs // {
+  inherit cargoArtifacts;
+  doCheck = false;
+
+  meta = {
+    description = "Compositor-agnostic touchscreen gesture daemon";
+    license = lib.licenses.mit;
+    mainProgram = "roland";
+    platforms = lib.platforms.linux;
+  };
+})

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,76 +1,88 @@
-use std::time::Duration;
+use std::{process::Child, time::Duration};
 
 use serde::Deserialize;
+
+const SIN_PI_8: f64 = 0.38268;
 
 #[derive(Deserialize, Debug)]
 pub struct GesturesConfig {
     pub gestures: Vec<GestureConfig>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub struct GestureConfig {
-    num_fingers: u32,
-    kind: GestureKind,
+    num_fingers: usize,
     action: String,
     min_duration: Option<u64>,
     max_duration: Option<u64>,
-    max_distance: Option<f64>,
     min_distance: Option<f64>,
+    max_distance: Option<f64>,
+    kind: GestureKind,
     on_edge: Option<EdgeRequirement>,
 }
 
 impl GestureConfig {
-    pub fn run(&self) {
+    pub fn run(&self) -> Result<Child, std::io::Error> {
         std::process::Command::new("sh")
             .arg("-c")
             .arg(&self.action)
             .spawn()
-            .expect("Failed to execute command");
     }
 
     pub fn should_trigger(
         &self,
-        num_finger: u32,
+        num_finger: usize,
+        spread_diff: Option<f64>,
+        centroid_diff: Option<(f64, f64)>,
         start_position: (f64, f64),
-        current_position: (f64, f64),
         screen_size: (f64, f64),
         duration: Duration,
     ) -> bool {
+        let gestures = self.conclude_gestures(
+            num_finger,
+            spread_diff,
+            centroid_diff,
+            start_position,
+            screen_size,
+            duration,
+        );
+
+        if gestures.contains(&self.kind) {
+            tracing::debug!(
+                "Gesture concluded {num_finger}/{gestures:?} <==> Trigger target {}/{:?}",
+                self.num_fingers,
+                self.kind
+            );
+            return true;
+        }
+        return false;
+    }
+
+    fn conclude_gestures(
+        &self,
+        num_finger: usize,
+        spread_diff: Option<f64>,
+        centroid_diff: Option<(f64, f64)>,
+        start_position: (f64, f64),
+        screen_size: (f64, f64),
+        duration: Duration,
+    ) -> Vec<GestureKind> {
+        let mut gestures = Vec::with_capacity(3);
+
         if num_finger != self.num_fingers {
-            tracing::debug!("Gesture finger count mismatch, ignoring");
-            return false;
+            return gestures;
         }
 
         if let Some(min_duration) = self.min_duration
             && duration < Duration::from_millis(min_duration)
         {
-            tracing::debug!("Gesture duration below min_duration, ignoring");
-            return false;
+            return gestures;
         }
 
         if let Some(max_duration) = self.max_duration
             && duration > Duration::from_millis(max_duration)
         {
-            tracing::debug!("Gesture duration exceeds max_duration, ignoring");
-            return false;
-        }
-
-        let dx = current_position.0 - start_position.0;
-        let dy = current_position.1 - start_position.1;
-        let distance = (dx * dx + dy * dy).sqrt();
-
-        if let Some(min_distance) = self.min_distance
-            && distance < min_distance
-        {
-            tracing::debug!("Gesture distance below min_distance, ignoring");
-            return false;
-        }
-
-        if let Some(max_distance) = self.max_distance
-            && distance > max_distance
-        {
-            tracing::debug!("Gesture distance exceeds max_distance, ignoring");
-            return false;
+            return gestures;
         }
 
         if !self.is_on_screen_edge(
@@ -79,42 +91,56 @@ impl GestureConfig {
             screen_size.0,
             screen_size.1,
         ) {
-            tracing::debug!("Gesture not on screen edge, ignoring");
-            return false;
+            return gestures;
         }
 
-        match self.kind {
-            GestureKind::SwipeUp => {
-                if is_vertical(dx, dy) && dy < 0.0 {
-                    tracing::debug!("Gesture swipe up detected");
-                    return true;
-                }
-            }
-            GestureKind::SwipeDown => {
-                if is_vertical(dx, dy) && dy > 0.0 {
-                    tracing::debug!("Gesture swipe down detected");
-                    return true;
-                }
-            }
-            GestureKind::SwipeLeft => {
-                if is_horizontal(dx, dy) && dx < 0.0 {
-                    tracing::debug!("Gesture swipe left detected");
-                    return true;
-                }
-            }
-            GestureKind::SwipeRight => {
-                if is_horizontal(dx, dy) && dx > 0.0 {
-                    tracing::debug!("Gesture swipe right detected");
-                    return true;
-                }
-            }
-            GestureKind::Press => {
-                // Press gesture does not depend on movement
-                return true;
-            }
+        let min_distance = self.min_distance.unwrap_or(0.0);
+
+        let (dx, dy) = match centroid_diff {
+            Some(diff) => diff,
+            None => return gestures,
+        };
+        let dr = dx.hypot(dy);
+
+        if dr < min_distance {
+            return gestures;
         }
 
-        false
+        if let Some(max_distance) = self.max_distance
+            && dr > max_distance
+        {
+            return gestures;
+        }
+
+        gestures.push(GestureKind::Hold);
+
+        match spread_diff {
+            Some(ds) if ds > min_distance => gestures.push(GestureKind::PinchOut),
+            Some(ds) if ds < -min_distance => gestures.push(GestureKind::PinchIn),
+            _ => {}
+        }
+
+        let projected = dx.hypot(dy) * SIN_PI_8;
+        match (
+            dx > projected,
+            dx < -projected,
+            dy > projected,
+            dy < -projected,
+        ) {
+            (true, false, false, false) => gestures.push(GestureKind::SwipeRight),
+            (false, true, false, false) => gestures.push(GestureKind::SwipeLeft),
+            (false, false, true, false) => gestures.push(GestureKind::SwipeDown),
+            (false, false, false, true) => gestures.push(GestureKind::SwipeUp),
+
+            (true, false, true, false) => gestures.push(GestureKind::SwipeDownRight),
+            (false, true, true, false) => gestures.push(GestureKind::SwipeDownLeft),
+            (true, false, false, true) => gestures.push(GestureKind::SwipeUpRight),
+            (false, true, false, true) => gestures.push(GestureKind::SwipeUpLeft),
+
+            _ => {}
+        };
+
+        return gestures;
     }
 
     fn is_on_screen_edge(&self, x: f64, y: f64, screen_width: f64, screen_height: f64) -> bool {
@@ -128,7 +154,7 @@ impl GestureConfig {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq)]
 pub enum EdgeRequirement {
     Top(u32),
     Left(u32),
@@ -136,13 +162,19 @@ pub enum EdgeRequirement {
     Right(u32),
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, PartialEq, Eq)]
 pub enum GestureKind {
     SwipeUp,
     SwipeDown,
     SwipeLeft,
     SwipeRight,
-    Press,
+    SwipeUpRight,
+    SwipeUpLeft,
+    SwipeDownRight,
+    SwipeDownLeft,
+    PinchIn,
+    PinchOut,
+    Hold,
 }
 
 impl GesturesConfig {
@@ -151,14 +183,6 @@ impl GesturesConfig {
         let config: GesturesConfig = toml::from_str(&content)?;
         Ok(config)
     }
-}
-
-fn is_vertical(dx: f64, dy: f64) -> bool {
-    dy.abs() > dx.abs()
-}
-
-fn is_horizontal(dx: f64, dy: f64) -> bool {
-    dx.abs() > dy.abs()
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -169,7 +169,7 @@ mod tests {
     #[test]
     fn test_from_path() {
         let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        path.push("config.toml");
+        path.push("config.example.toml");
 
         let config = GesturesConfig::from_path(&path).unwrap();
         println!("{:?}", config)

--- a/src/gesture.rs
+++ b/src/gesture.rs
@@ -1,12 +1,54 @@
-use std::time::Instant;
+use std::{
+    process::Child,
+    time::{Duration, Instant},
+};
+
+use thiserror::Error;
 
 use crate::config::GesturesConfig;
 
+const MAX_FINGERS: usize = 4;
+
+#[derive(Error, Debug)]
+pub enum GestureError {
+    #[error("no active touches/fingers")]
+    NoActiveTouch,
+    #[error("no matching gesture found")]
+    NoGestureMatched,
+    #[error("failed to execute gesture command: {0}")]
+    CommandFailed(#[from] std::io::Error),
+}
+
+#[derive(Debug)]
+pub struct TouchTrace {
+    slot: Option<u32>,
+    init_pos: (f64, f64),
+    current_pos: (f64, f64),
+    start_time: Instant,
+}
+
+impl TouchTrace {
+    pub fn new(slot: Option<u32>, x: f64, y: f64) -> Self {
+        Self {
+            slot,
+            init_pos: (x, y),
+            current_pos: (x, y),
+            start_time: Instant::now(),
+        }
+    }
+
+    pub fn current_distance_to(&self, x: f64, y: f64) -> f64 {
+        (x - self.current_pos.0).hypot(y - self.current_pos.1)
+    }
+
+    pub fn init_distance_to(&self, x: f64, y: f64) -> f64 {
+        (x - self.init_pos.0).hypot(y - self.init_pos.1)
+    }
+}
+
 #[derive(Debug)]
 pub struct GestureState {
-    position: (f64, f64),
-    active_touches: u32,
-    swipe: Option<Gesture>,
+    traces: Vec<TouchTrace>,
     config: GesturesConfig,
     screen_dimensions: (f64, f64),
 }
@@ -14,95 +56,128 @@ pub struct GestureState {
 impl GestureState {
     pub fn new(config: GesturesConfig, screen_width: f64, screen_height: f64) -> Self {
         Self {
-            position: (0.0, 0.0),
-            active_touches: 0,
-            swipe: None,
+            traces: Vec::with_capacity(MAX_FINGERS),
             config,
             screen_dimensions: (screen_width, screen_height),
         }
     }
-}
 
-#[derive(Debug)]
-struct Gesture {
-    start_position: (f64, f64),
-    start_time: Instant,
-    triggered: bool,
-}
-
-impl Gesture {
-    fn new(start_position: (f64, f64)) -> Self {
-        tracing::debug!("New gesture with position {start_position:?}");
-        Self {
-            start_position,
-            start_time: Instant::now(),
-            triggered: false,
+    pub fn update(&mut self, slot: Option<u32>, x: f64, y: f64) {
+        for t in self.traces.iter_mut().filter(|t| t.slot == slot) {
+            t.current_pos = (x, y);
         }
-    }
-}
 
-impl GestureState {
-    pub fn update(&mut self, x: f64, y: f64) {
-        tracing::trace!("Updating position to ({}, {})", x, y);
-        self.position = (x, y);
-        self.check_press_gestures();
+        self.handle_gesture();
     }
 
-    fn check_press_gestures(&mut self) {
-        if let Some(gesture) = &mut self.swipe {
-            if gesture.triggered {
-                return;
-            }
-
-            let duration = gesture.start_time.elapsed();
-
-            for gesture_config in self.config.gestures.iter() {
-                if gesture_config.should_trigger(
-                    self.active_touches,
-                    gesture.start_position,
-                    self.position,
-                    self.screen_dimensions,
-                    duration,
-                ) {
-                    tracing::info!("Triggering press gesture: {:?}", gesture_config);
-                    gesture_config.run();
-                    gesture.triggered = true;
-                    break;
-                }
-            }
-        }
+    pub fn touch_down(&mut self, slot: Option<u32>, x: f64, y: f64) {
+        self.traces.push(TouchTrace::new(slot, x, y))
     }
 
-    pub fn handle_touch_down(&mut self, x: f64, y: f64) {
-        self.position = (x, y);
-        self.active_touches += 1;
-        tracing::trace!("Active touches incremented {}", self.active_touches);
-        tracing::debug!("Touch down at {:?}", self.position);
-        self.swipe = Some(Gesture::new(self.position));
+    pub fn touch_up(&mut self, slot: Option<u32>) {
+        self.handle_gesture();
+        self.traces.retain(|t| t.slot != slot);
     }
 
-    pub fn handle_touch_up(&mut self) {
-        if let Some(swipe) = self.swipe.take() {
-            if !swipe.triggered {
-                for gesture in self.config.gestures.iter() {
-                    let duration = swipe.start_time.elapsed();
-                    if gesture.should_trigger(
-                        self.active_touches,
-                        swipe.start_position,
-                        self.position,
-                        self.screen_dimensions,
-                        duration,
-                    ) {
-                        tracing::info!("Triggering gesture: {:?}", gesture);
-                        gesture.run();
-                        break;
+    fn init_centeroid(&self) -> Option<(f64, f64)> {
+        if self.traces.is_empty() {
+            return None;
+        };
+
+        let n = self.traces.len() as f64;
+        let sum_x: f64 = self.traces.iter().map(|t| t.init_pos.0).sum();
+        let sum_y: f64 = self.traces.iter().map(|t| t.init_pos.1).sum();
+
+        Some((sum_x / n, sum_y / n))
+    }
+
+    fn current_centroid(&self) -> Option<(f64, f64)> {
+        if self.traces.is_empty() {
+            return None;
+        };
+
+        let n = self.traces.len() as f64;
+        let sum_x: f64 = self.traces.iter().map(|t| t.current_pos.0).sum();
+        let sum_y: f64 = self.traces.iter().map(|t| t.current_pos.1).sum();
+
+        Some((sum_x / n, sum_y / n))
+    }
+
+    fn init_spread(&self) -> Option<f64> {
+        let n = self.traces.len() as f64;
+        self.init_centeroid().map(|(cx, cy)| {
+            self.traces
+                .iter()
+                .map(|t| t.init_distance_to(cx, cy))
+                .sum::<f64>()
+                / n
+        })
+    }
+
+    fn current_spread(&self) -> Option<f64> {
+        let n = self.traces.len() as f64;
+        self.current_centroid().map(|(cx, cy)| {
+            self.traces
+                .iter()
+                .map(|t| t.current_distance_to(cx, cy))
+                .sum::<f64>()
+                / n
+        })
+    }
+
+    fn dispatch(&self) -> Result<Child, GestureError> {
+        let spread_diff = self
+            .current_spread()
+            .zip(self.init_spread())
+            .map(|(n, o)| n - o);
+
+        let centroid_diff = self
+            .current_centroid()
+            .zip(self.init_centeroid())
+            .map(|((xn, yn), (xo, yo))| (xn - xo, yn - yo));
+
+        tracing::debug!("Spread: {spread_diff:?}, Centroid: {centroid_diff:?}");
+
+        for c in &self.config.gestures {
+            let init_centeroid = self.init_centeroid().ok_or(GestureError::NoActiveTouch)?;
+            let longest_duration = self.longest_duration().ok_or(GestureError::NoActiveTouch)?;
+
+            if c.should_trigger(
+                self.traces.len(),
+                spread_diff,
+                centroid_diff,
+                init_centeroid,
+                self.screen_dimensions,
+                longest_duration,
+            ) {
+                tracing::debug!("Gesture {c:?} concluded");
+                match c.run() {
+                    Ok(child) => return Ok(child),
+                    Err(e) => {
+                        tracing::error!("Failed to run command: {e}");
+                        return Err(GestureError::CommandFailed(e.into()));
                     }
                 }
             }
-
-            tracing::debug!("remove active touch");
-            self.active_touches = 0;
-            self.swipe = None;
         }
+        Err(GestureError::NoGestureMatched)
+    }
+
+    fn handle_gesture(&mut self) {
+        match self.dispatch() {
+            Ok(_) => self.traces.clear(),
+            Err(GestureError::CommandFailed(e)) => {
+                tracing::error!("Failed to run gesture command: {e}");
+                self.traces.clear();
+            }
+            _ => {}
+        }
+    }
+
+    fn longest_duration(&self) -> Option<Duration> {
+        self.traces
+            .iter()
+            .map(|trace| Instant::now().saturating_duration_since(trace.start_time))
+            .max()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,6 @@ use std::os::unix::{
     io::{AsFd, OwnedFd},
 };
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use tracing::Level;
 use tracing_subscriber::FmtSubscriber;
 
@@ -17,17 +16,22 @@ extern crate libc;
 use libc::{O_RDONLY, O_RDWR, O_WRONLY};
 
 use crate::gesture::GestureState;
+use crate::output::get_output_dimensions;
 
 mod config;
 mod gesture;
+mod output;
 
 /// Touch Gesture Daemon
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Args {
-    /// Size of screen edge zone in pixels
     #[arg(long, short)]
     config: PathBuf,
+
+    /// Increase log verbosity (-v info, -vv debug, -vvv trace)
+    #[arg(short, action = clap::ArgAction::Count)]
+    verbose: u8,
 }
 
 struct Interface;
@@ -51,24 +55,34 @@ impl LibinputInterface for Interface {
 fn main() {
     let args = Args::parse();
 
-    let subscriber = FmtSubscriber::builder()
-        .with_max_level(Level::DEBUG)
-        .finish();
+    let log_level = match args.verbose {
+        0 => Level::WARN,
+        1 => Level::INFO,
+        2 => Level::DEBUG,
+        _ => Level::TRACE,
+    };
 
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(log_level)
+        .finish();
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
     let mut input = Libinput::new_with_udev(Interface);
     input.udev_assign_seat("seat0").unwrap();
-    let (width, height) = get_output_dimensions().unwrap();
+
+    let (width, height) = get_output_dimensions().unwrap_or_else(|| {
+        tracing::warn!("Could not detect output dimensions, defaulting to 1920x1080");
+        (1920, 1080)
+    });
+    tracing::info!("Using screen dimensions: {}x{}", width, height);
 
     let config = config::GesturesConfig::from_path(&args.config).unwrap();
     let mut state = GestureState::new(config, width as f64, height as f64);
 
     loop {
-        // Wait for events using poll() to avoid busy-waiting
         let poll_fd = PollFd::from_borrowed_fd(input.as_fd(), PollFlags::IN);
-        poll(&mut [poll_fd], -1).unwrap();
+        poll(&mut [poll_fd], None).unwrap();
 
-        // Process events when available
         input.dispatch().unwrap();
         for event in &mut input {
             match event {
@@ -95,124 +109,4 @@ fn main() {
     }
 }
 
-enum Compositor {
-    Niri,
-    Hyprland,
-    Sway,
-}
 
-fn detect_compositor() -> Option<Compositor> {
-    let desktop = std::env::var("XDG_CURRENT_DESKTOP")
-        .unwrap_or_default()
-        .to_lowercase();
-
-    match (
-        desktop.as_str(),
-        std::env::var("NIRI_SOCKET").is_ok(),
-        std::env::var("HYPRLAND_INSTANCE_SIGNATURE").is_ok(),
-        std::env::var("SWAYSOCK").is_ok(),
-    ) {
-        (_, true, _, _) => Some(Compositor::Niri),
-        (_, _, true, _) => Some(Compositor::Hyprland),
-        (_, _, _, true) => Some(Compositor::Sway),
-        (d, _, _, _) if d.contains("niri") => Some(Compositor::Niri),
-        (d, _, _, _) if d.contains("hyprland") => Some(Compositor::Hyprland),
-        (d, _, _, _) if d.contains("sway") => Some(Compositor::Sway),
-        _ => None,
-    }
-}
-
-fn get_output_dimensions() -> Option<(u32, u32)> {
-    match detect_compositor()? {
-        Compositor::Niri => get_output_dimensions_niri(),
-        Compositor::Hyprland => get_output_dimensions_hyprland(),
-        Compositor::Sway => get_output_dimensions_sway(),
-    }
-}
-
-fn get_output_dimensions_niri() -> Option<(u32, u32)> {
-    #[derive(serde::Deserialize)]
-    struct OutputData {
-        logical: Option<LogicalDimensions>,
-    }
-
-    #[derive(serde::Deserialize)]
-    struct LogicalDimensions {
-        width: u32,
-        height: u32,
-    }
-
-    let output = Command::new("niri")
-        .args(["msg", "-j", "outputs"])
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let outputs: std::collections::HashMap<String, OutputData> =
-        serde_json::from_slice(&output.stdout).ok()?;
-
-    outputs
-        .values()
-        .find_map(|o| o.logical.as_ref().map(|l| (l.width, l.height)))
-}
-
-fn get_output_dimensions_hyprland() -> Option<(u32, u32)> {
-    #[derive(serde::Deserialize)]
-    struct Monitor {
-        width: u32,
-        height: u32,
-        focused: bool,
-    }
-
-    let output = Command::new("hyprctl")
-        .args(["monitors", "-j"])
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let monitors: Vec<Monitor> = serde_json::from_slice(&output.stdout).ok()?;
-
-    // prefer focused monitor, fall back to first
-    monitors
-        .iter()
-        .find(|m| m.focused)
-        .or_else(|| monitors.first())
-        .map(|m| (m.width, m.height))
-}
-
-fn get_output_dimensions_sway() -> Option<(u32, u32)> {
-    #[derive(serde::Deserialize)]
-    struct Output {
-        rect: Rect,
-        focused: bool,
-    }
-
-    #[derive(serde::Deserialize)]
-    struct Rect {
-        width: u32,
-        height: u32,
-    }
-
-    let output = Command::new("swaymsg")
-        .args(["-t", "get_outputs", "--raw"])
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let outputs: Vec<Output> = serde_json::from_slice(&output.stdout).ok()?;
-
-    outputs
-        .iter()
-        .find(|o| o.focused)
-        .or_else(|| outputs.first())
-        .map(|o| (o.rect.width, o.rect.height))
-}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use input::event::TouchEvent;
-use input::event::touch::TouchEventPosition;
+use input::event::touch::{TouchEventPosition, TouchEventSlot};
 use input::{Event as InputEvent, Libinput, LibinputInterface};
 use rustix::event::{PollFd, PollFlags, poll};
 use std::fs::{File, OpenOptions};
@@ -74,18 +74,20 @@ fn main() {
             match event {
                 InputEvent::Touch(TouchEvent::Motion(touch_event)) => {
                     state.update(
+                        touch_event.slot(),
                         touch_event.x_transformed(width),
                         touch_event.y_transformed(height),
                     );
                 }
                 InputEvent::Touch(TouchEvent::Down(touch_event)) => {
-                    state.handle_touch_down(
+                    state.touch_down(
+                        touch_event.slot(),
                         touch_event.x_transformed(width),
                         touch_event.y_transformed(height),
                     );
                 }
-                InputEvent::Touch(TouchEvent::Up(_)) => {
-                    state.handle_touch_up();
+                InputEvent::Touch(TouchEvent::Up(touch_event)) => {
+                    state.touch_up(touch_event.slot());
                 }
                 _ => {}
             }
@@ -93,10 +95,45 @@ fn main() {
     }
 }
 
+enum Compositor {
+    Niri,
+    Hyprland,
+    Sway,
+}
+
+fn detect_compositor() -> Option<Compositor> {
+    let desktop = std::env::var("XDG_CURRENT_DESKTOP")
+        .unwrap_or_default()
+        .to_lowercase();
+
+    match (
+        desktop.as_str(),
+        std::env::var("NIRI_SOCKET").is_ok(),
+        std::env::var("HYPRLAND_INSTANCE_SIGNATURE").is_ok(),
+        std::env::var("SWAYSOCK").is_ok(),
+    ) {
+        (_, true, _, _) => Some(Compositor::Niri),
+        (_, _, true, _) => Some(Compositor::Hyprland),
+        (_, _, _, true) => Some(Compositor::Sway),
+        (d, _, _, _) if d.contains("niri") => Some(Compositor::Niri),
+        (d, _, _, _) if d.contains("hyprland") => Some(Compositor::Hyprland),
+        (d, _, _, _) if d.contains("sway") => Some(Compositor::Sway),
+        _ => None,
+    }
+}
+
 fn get_output_dimensions() -> Option<(u32, u32)> {
+    match detect_compositor()? {
+        Compositor::Niri => get_output_dimensions_niri(),
+        Compositor::Hyprland => get_output_dimensions_hyprland(),
+        Compositor::Sway => get_output_dimensions_sway(),
+    }
+}
+
+fn get_output_dimensions_niri() -> Option<(u32, u32)> {
     #[derive(serde::Deserialize)]
     struct OutputData {
-        logical: LogicalDimensions,
+        logical: Option<LogicalDimensions>,
     }
 
     #[derive(serde::Deserialize)]
@@ -106,9 +143,7 @@ fn get_output_dimensions() -> Option<(u32, u32)> {
     }
 
     let output = Command::new("niri")
-        .arg("msg")
-        .arg("-j")
-        .arg("outputs")
+        .args(["msg", "-j", "outputs"])
         .output()
         .ok()?;
 
@@ -116,12 +151,68 @@ fn get_output_dimensions() -> Option<(u32, u32)> {
         return None;
     }
 
-    let json_str = String::from_utf8(output.stdout).ok()?;
     let outputs: std::collections::HashMap<String, OutputData> =
-        serde_json::from_str(&json_str).ok()?;
+        serde_json::from_slice(&output.stdout).ok()?;
 
     outputs
         .values()
-        .next()
-        .map(|output_data| (output_data.logical.width, output_data.logical.height))
+        .find_map(|o| o.logical.as_ref().map(|l| (l.width, l.height)))
+}
+
+fn get_output_dimensions_hyprland() -> Option<(u32, u32)> {
+    #[derive(serde::Deserialize)]
+    struct Monitor {
+        width: u32,
+        height: u32,
+        focused: bool,
+    }
+
+    let output = Command::new("hyprctl")
+        .args(["monitors", "-j"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let monitors: Vec<Monitor> = serde_json::from_slice(&output.stdout).ok()?;
+
+    // prefer focused monitor, fall back to first
+    monitors
+        .iter()
+        .find(|m| m.focused)
+        .or_else(|| monitors.first())
+        .map(|m| (m.width, m.height))
+}
+
+fn get_output_dimensions_sway() -> Option<(u32, u32)> {
+    #[derive(serde::Deserialize)]
+    struct Output {
+        rect: Rect,
+        focused: bool,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Rect {
+        width: u32,
+        height: u32,
+    }
+
+    let output = Command::new("swaymsg")
+        .args(["-t", "get_outputs", "--raw"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let outputs: Vec<Output> = serde_json::from_slice(&output.stdout).ok()?;
+
+    outputs
+        .iter()
+        .find(|o| o.focused)
+        .or_else(|| outputs.first())
+        .map(|o| (o.rect.width, o.rect.height))
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,0 +1,203 @@
+//! Compositor-agnostic screen dimension discovery via Wayland protocols.
+//!
+//! Strategy:
+//!   1. Try xdg-output-unstable-v1 for logical dimensions (handles HiDPI correctly).
+//!   2. Fall back to wl_output physical size if xdg-output is unavailable.
+
+use std::sync::{Arc, Mutex};
+
+use wayland_client::{
+    Connection, Dispatch, EventQueue, QueueHandle,
+    globals::{GlobalList, GlobalListContents, registry_queue_init},
+    protocol::{
+        wl_output::{self, WlOutput},
+        wl_registry::{self, WlRegistry},
+    },
+};
+use wayland_protocols::xdg::xdg_output::zv1::client::{
+    zxdg_output_manager_v1::ZxdgOutputManagerV1,
+    zxdg_output_v1::{self, ZxdgOutputV1},
+};
+
+// ── State ─────────────────────────────────────────────────────────────────────
+
+#[derive(Default)]
+struct OutputState {
+    // Physical size from wl_output (fallback)
+    phys_width: i32,
+    phys_height: i32,
+    // Logical size from xdg-output (preferred)
+    logical_width: Option<i32>,
+    logical_height: Option<i32>,
+    done: bool,
+}
+
+struct AppData {
+    outputs: Vec<(WlOutput, Arc<Mutex<OutputState>>)>,
+    xdg_manager: Option<ZxdgOutputManagerV1>,
+    xdg_outputs: Vec<(ZxdgOutputV1, Arc<Mutex<OutputState>>)>,
+}
+
+// ── wl_registry ───────────────────────────────────────────────────────────────
+
+impl Dispatch<WlRegistry, GlobalListContents> for AppData {
+    fn event(
+        _state: &mut Self,
+        _proxy: &WlRegistry,
+        _event: wl_registry::Event,
+        _data: &GlobalListContents,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        // Handled via GlobalList; nothing needed here.
+    }
+}
+
+// ── wl_output ────────────────────────────────────────────────────────────────
+
+impl Dispatch<WlOutput, Arc<Mutex<OutputState>>> for AppData {
+    fn event(
+        _state: &mut Self,
+        _proxy: &WlOutput,
+        event: wl_output::Event,
+        data: &Arc<Mutex<OutputState>>,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        let mut s = data.lock().unwrap();
+        match event {
+            wl_output::Event::Mode { width, height, .. } => {
+                s.phys_width = width;
+                s.phys_height = height;
+            }
+            wl_output::Event::Done => {
+                s.done = true;
+            }
+            _ => {}
+        }
+    }
+}
+
+// ── xdg-output ───────────────────────────────────────────────────────────────
+
+impl Dispatch<ZxdgOutputManagerV1, ()> for AppData {
+    fn event(
+        _: &mut Self,
+        _: &ZxdgOutputManagerV1,
+        _: wayland_protocols::xdg::xdg_output::zv1::client::zxdg_output_manager_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+    }
+}
+
+impl Dispatch<ZxdgOutputV1, Arc<Mutex<OutputState>>> for AppData {
+    fn event(
+        _state: &mut Self,
+        _proxy: &ZxdgOutputV1,
+        event: zxdg_output_v1::Event,
+        data: &Arc<Mutex<OutputState>>,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+    ) {
+        let mut s = data.lock().unwrap();
+        match event {
+            zxdg_output_v1::Event::LogicalSize { width, height } => {
+                s.logical_width = Some(width);
+                s.logical_height = Some(height);
+            }
+            zxdg_output_v1::Event::Done => {
+                s.done = true;
+            }
+            _ => {}
+        }
+    }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Returns the logical (post-scale) dimensions of the first available output.
+///
+/// Uses xdg-output-unstable-v1 when the compositor supports it; falls back to
+/// the physical mode size reported by wl_output.  Returns `None` if no output
+/// is found or the Wayland connection fails.
+pub fn get_output_dimensions() -> Option<(u32, u32)> {
+    let conn = Connection::connect_to_env().ok()?;
+    let (globals, mut queue): (GlobalList, EventQueue<AppData>) =
+        registry_queue_init(&conn).ok()?;
+
+    let qh = queue.handle();
+
+    // Bind wl_output (version 2 minimum for Done event)
+    let output_states: Vec<Arc<Mutex<OutputState>>> = globals
+        .contents()
+        .clone_list()
+        .iter()
+        .filter(|g| g.interface == "wl_output")
+        .map(|g| {
+            let state = Arc::new(Mutex::new(OutputState::default()));
+            globals.registry().bind::<WlOutput, _, AppData>(
+                g.name,
+                2.min(g.version),
+                &qh,
+                state.clone(),
+            );
+            state
+        })
+        .collect();
+
+    if output_states.is_empty() {
+        tracing::warn!("No wl_output globals found");
+        return None;
+    }
+
+    // Try to bind xdg-output manager
+    let xdg_manager = globals
+        .bind::<ZxdgOutputManagerV1, _, _>(&qh, 1..=3, ())
+        .ok();
+
+    let mut app = AppData {
+        outputs: Vec::new(),
+        xdg_manager,
+        xdg_outputs: Vec::new(),
+    };
+
+    // If xdg-output is available, create an xdg output for each wl_output
+    if let Some(ref mgr) = app.xdg_manager {
+        for (wl_out, state) in app.outputs.iter() {
+            let xdg_out = mgr.get_xdg_output(wl_out, &qh, state.clone());
+            app.xdg_outputs.push((xdg_out, state.clone()));
+        }
+    }
+
+    // Round-trip until all outputs report Done
+    for _ in 0..5 {
+        queue.roundtrip(&mut app).ok()?;
+        if output_states.iter().all(|s| s.lock().unwrap().done) {
+            break;
+        }
+    }
+
+    // Pick first output with usable dimensions
+    for state in &output_states {
+        let s = state.lock().unwrap();
+        if let (Some(w), Some(h)) = (s.logical_width, s.logical_height) {
+            if w > 0 && h > 0 {
+                tracing::debug!("Output logical dimensions (xdg-output): {}x{}", w, h);
+                return Some((w as u32, h as u32));
+            }
+        }
+        if s.phys_width > 0 && s.phys_height > 0 {
+            tracing::debug!(
+                "Output dimensions (wl_output fallback): {}x{}",
+                s.phys_width,
+                s.phys_height
+            );
+            return Some((s.phys_width as u32, s.phys_height as u32));
+        }
+    }
+
+    tracing::warn!("Could not determine output dimensions from Wayland");
+    None
+}


### PR DESCRIPTION
Transforms roland from a personal Niri-specific script into a general-purpose compositor-agnostic touch gesture daemon.

**Changes:**

- Bump version to `0.2.0`
- Wayland output detection via `xdg-output-unstable-v1` with `wl_output` fallback
- Pinch gesture kinds (`PinchIn`, `PinchOut`)
- Diagonal swipe gesture kinds (`SwipeUpLeft`, `SwipeUpRight`, `SwipeDownLeft`, `SwipeDownRight`)
- Hold gesture kind
- Edge-aware gestures (`on_edge`)
- Duration thresholds (`min_duration`, `max_duration`)
- Nix flake with overlay and Home Manager module (`services.roland`)
- Drop `rust-overlay` dependency — use nixpkgs toolchain directly
- Updated README with Nix usage, permissions, and full configuration reference